### PR TITLE
Implement a more general node id generator

### DIFF
--- a/src/clj_uuid.clj
+++ b/src/clj_uuid.clj
@@ -234,7 +234,7 @@
         clk-high  (bitmop/dpb (bitmop/mask 2 6)
                               (bitmop/ldb (bitmop/mask 6 8) @clock/clock-seq) 0x2)
         clk-low   (bitmop/ldb (bitmop/mask 8 0) @clock/clock-seq)
-        lsb       (bitmop/assemble-bytes (concat [clk-high clk-low] (clock/make-node-id)))]
+        lsb       (bitmop/assemble-bytes (concat [clk-high clk-low] clock/+node-id+))]
     (UUID. msb lsb)))
 
 ;; (v1)


### PR DESCRIPTION
The previous implementation of make-node-id always resulted in a NPE on my system.
I copied the [datastax's implementation](http://grepcode.com/file/repo1.maven.org/maven2/com.datastax.cassandra/cassandra-driver-core/2.1.3/com/datastax/driver/core/utils/UUIDs.java#72) from their cassandra client.

The comment from their code is that the MAC address cannot be fetched from pure java, so lets gather as much unique information as possible.

I also changed the v1 builder to use the constant version of the node id to improve performance.