### PR TITLE
Consider set :scope "provided" for clojure dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,8 +10,8 @@
   :url          "https://github.com/danlentz/clj-uuid"
   :license      {:name "Eclipse Public License"
                   :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure                "1.6.0"]
-                 [primitive-math                     "0.1.4"]]
+  :dependencies [[org.clojure/clojure "1.6.0" :scope "provided"]
+                 [primitive-math      "0.1.4"]]
   :codox    {:output-dir  "doc/api"
              :src-dir-uri "https://github.com/danlentz/clj-uuid/blob/master/"
              :src-linenum-anchor-prefix "L"


### PR DESCRIPTION
This allows avoid to force the transitive dependency of concrete clojure version.