### PR TITLE
only call make-node-id when needed

### DIFF
--- a/src/clj_uuid/node.clj
+++ b/src/clj_uuid/node.clj
@@ -141,10 +141,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def node-id
-  (memoize make-node-id))
+  (delay make-node-id))
 
 (def ^:const +node-id+
-  (assemble-bytes (cons 0 (cons 0 (node-id)))))
+  (assemble-bytes (cons 0 (cons 0 (@node-id)))))
 
 (def ^:const +v1-lsb+
   (let [clk-high  (dpb (mask 2 6) (ldb (mask 6 8) +clock-sequence+) 0x2)

--- a/test/clj_uuid/node_test.clj
+++ b/test/clj_uuid/node_test.clj
@@ -5,10 +5,10 @@
 
 (deftest check-node-id
   (testing "existance and type of node id...")
-  (is (= (node-id) (node-id)))
-  (is (coll? (node-id)))
-  (is (= 6 (count (node-id))))
-  (is (every? number? (node-id)))
+  (is (= (@node-id) (@node-id)))
+  (is (coll? (@node-id)))
+  (is (= 6 (count (@node-id))))
+  (is (every? number? (@node-id)))
   (is (= 1 (bit-and 0x01 +node-id+)))
   (is (instance? Long +node-id+)))
  


### PR DESCRIPTION
use delay instead of memoize
that makes sure that the call doesn't happen when not needed
and yet still caches the result