### PR TITLE
For Clojure 1.9: Exclude uuid? when referring clojure.core

### DIFF
--- a/src/clj_uuid.clj
+++ b/src/clj_uuid.clj
@@ -1,5 +1,5 @@
 (ns clj-uuid
-  (:refer-clojure :exclude [==])
+  (:refer-clojure :exclude [== uuid?])
   (:require [clj-uuid
              [constants :refer :all]
              [util      :refer :all]

--- a/test/clj_uuid/api_test.clj
+++ b/test/clj_uuid/api_test.clj
@@ -1,4 +1,5 @@
 (ns clj-uuid.api-test
+  (:refer-clojure :exclude [uuid?])
   (:require [clojure.test :refer :all]
             [clj-uuid     :refer :all]))
 

--- a/test/clj_uuid/v1_test.clj
+++ b/test/clj_uuid/v1_test.clj
@@ -1,7 +1,7 @@
 (ns clj-uuid.v1-test
   (:require [clojure.test   :refer :all]
             [clojure.set]
-            [clj-uuid :refer :all]))
+            [clj-uuid :refer [v1 get-timestamp]]))
 
 
 (deftest check-v1-concurrency
@@ -25,23 +25,3 @@
       (testing "concurrent v1 monotonic increasing..."
         (is (every? identity
               (map #(apply < (map get-timestamp %)) answers)))))))
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/test/clj_uuid/v3_test.clj
+++ b/test/clj_uuid/v3_test.clj
@@ -1,4 +1,5 @@
 (ns clj-uuid.v3-test
+  (:refer-clojure :exclude [uuid?])
   (:require [clojure.test   :refer :all]
             [clj-uuid       :refer :all]))
 

--- a/test/clj_uuid/v4_test.clj
+++ b/test/clj_uuid/v4_test.clj
@@ -1,4 +1,5 @@
 (ns clj-uuid.v4-test
+  (:refer-clojure :exclude [uuid?])
   (:require [clojure.test   :refer :all]
             [clj-uuid       :refer :all]))
 
@@ -10,5 +11,3 @@
     (is (= (v4  0 -1)  #uuid "00000000-0000-4000-bfff-ffffffffffff"))
     (is (= (v4 -1  0)  #uuid "ffffffff-ffff-4fff-8000-000000000000"))
     (is (= (v4 -1 -1)  #uuid "ffffffff-ffff-4fff-bfff-ffffffffffff"))))
-
-

--- a/test/clj_uuid/v5_test.clj
+++ b/test/clj_uuid/v5_test.clj
@@ -1,4 +1,5 @@
 (ns clj-uuid.v5-test
+  (:refer-clojure :exclude [uuid?])
   (:require [clojure.test   :refer :all]
             [clj-uuid       :refer :all]))
 


### PR DESCRIPTION
Clojure 1.9 adds a new function `uuid?` to clojure.core. This means that when you try to use clj-uuid with Clojure 1.9, you'll get warnings like this:

    Warning: protocol #'clj-uuid/UUIDRfc4122 is overwriting function uuid?
    WARNING: uuid? already refers to: #'clojure.core/uuid? in namespace: clj-uuid, being replaced by: #'clj-uuid/uuid?

This patch excludes `uuid?` from core and thus avoids the warnings.