### PR TITLE
Do not embed constant node ID in compiled code

### DIFF
--- a/src/clj_uuid/node.clj
+++ b/src/clj_uuid/node.clj
@@ -143,10 +143,10 @@
 (def node-id
   (memoize make-node-id))
 
-(def ^:const +node-id+
+(def +node-id+
   (assemble-bytes (cons 0 (cons 0 (node-id)))))
 
-(def ^:const +v1-lsb+
+(def +v1-lsb+
   (let [clk-high  (dpb (mask 2 6) (ldb (mask 6 8) +clock-sequence+) 0x2)
         clk-low   (ldb (mask 8 0) +clock-sequence+)]
     (dpb (mask 8 56) (dpb (mask 8 48) +node-id+ clk-low) clk-high)))


### PR DESCRIPTION
When a Var is created with the ^:const declaration, the Clojure
compiler will replace all usages of that Var with its value.

This happens at compile time. When loading from source, this has no
impact, but if clj-uuid is ahead-of-time (AOT) compiled then the node
ID is generated once and its value embedded in the compiled artifact.

For example, if an application is AOT-compiled once and deployed on
multiple machines, it will use the same node ID on all machines.

This fixes #37.