### PR TITLE
defer hostname lookup until it is needed

### DIFF
--- a/src/clj_uuid.clj
+++ b/src/clj_uuid.clj
@@ -485,7 +485,7 @@
         msb       (bit-or time-high
                    (bit-shift-left time-low 32)
                    (bit-shift-left time-mid 16))]
-    (UUID. msb node/+v1-lsb+)))
+    (UUID. msb (node/+v1-lsb+))))
 
 
 

--- a/src/clj_uuid/node.clj
+++ b/src/clj_uuid/node.clj
@@ -36,7 +36,7 @@
 ;; prepending two other (computed) bytes to the node-id before
 ;; bitwise assembly.  
 ;; 
-;;  (cons clock-high (cons clock-low +node-id+))
+;;  (cons clock-high (cons clock-low (+node-id+)))
 ;;
 ;;  
 ;;      ( <BYTE> . <BYTE> . <BYTE> <BYTE> <BYTE> <BYTE> <BYTE> <BYTE>)
@@ -140,13 +140,16 @@
 ;; Public NodeID API
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def node-id
-  (memoize make-node-id))
+(def node-id make-node-id)
 
-(def +node-id+
+(defn +node-id+
+  []
   (assemble-bytes (cons 0 (cons 0 (node-id)))))
 
-(def +v1-lsb+
+(defn- +v1-lsb+'
+  []
   (let [clk-high  (dpb (mask 2 6) (ldb (mask 6 8) +clock-sequence+) 0x2)
         clk-low   (ldb (mask 8 0) +clock-sequence+)]
-    (dpb (mask 8 56) (dpb (mask 8 48) +node-id+ clk-low) clk-high)))
+    (dpb (mask 8 56) (dpb (mask 8 48) (+node-id+) clk-low) clk-high)))
+
+(def +v1-lsb+ (memoize +v1-lsb+'))

--- a/test/clj_uuid/node_test.clj
+++ b/test/clj_uuid/node_test.clj
@@ -9,7 +9,7 @@
   (is (coll? (node-id)))
   (is (= 6 (count (node-id))))
   (is (every? number? (node-id)))
-  (is (= 1 (bit-and 0x01 +node-id+)))
-  (is (instance? Long +node-id+)))
+  (is (= 1 (bit-and 0x01 (+node-id+))))
+  (is (instance? Long (+node-id+))))
  
 


### PR DESCRIPTION
Another fix for #31. This postpones hostname look up from load time to only when it's first needed.