### PR TITLE
Implementing UUIDable for byte arrays

### DIFF
--- a/src/clj_uuid.clj
+++ b/src/clj_uuid.clj
@@ -9,6 +9,7 @@
   (:import [java.security MessageDigest]
            [java.io       ByteArrayOutputStream
                           ObjectOutputStream]
+           [java.nio      ByteBuffer]
            [java.net      URI
                           URL]
            [java.util     UUID
@@ -702,6 +703,13 @@
   (uuid? [_] false))
 
 (extend-protocol UUIDable
+  (Class/forName "[B") ; byte array
+  (as-uuid [^bytes ba]
+    (let [bb (ByteBuffer/wrap ba)]
+      (UUID. (.getLong bb) (.getLong bb))))
+  (uuidable? [^bytes ba]
+    (= 16 (alength ba)))
+
   String
   (uuidable? ^boolean [s]
     (or

--- a/test/clj_uuid/api_test.clj
+++ b/test/clj_uuid/api_test.clj
@@ -127,3 +127,8 @@
     (is (false? (uuid-urn-string? nil)))
 
     (is (false? (uuid-vec? nil)))))
+
+(deftest byte-array-round-trip-test
+  (testing "round-trip via byte-array"
+    (let [uuid #uuid "4787199e-c0e2-4609-b5b8-284f2b7d117d"]
+      (is (= uuid (as-uuid (as-byte-array uuid)))))))


### PR DESCRIPTION
Hi Dan - just a quick one, I've implemented UUIDable for byte arrays, so that we can turn byte arrays back into UUIDs.

Thanks for a really useful util library!

James