### PR TITLE
Fix name collision for unsigned-bit-shift-right

### DIFF
--- a/src/clj_uuid/bitmop.clj
+++ b/src/clj_uuid/bitmop.clj
@@ -1,6 +1,7 @@
 (ns clj-uuid.bitmop
   (:refer-clojure :exclude [* + - / < > <= >= == rem bit-or bit-and bit-xor
                             bit-not bit-shift-left bit-shift-right
+                            unsigned-bit-shift-right
                             byte short int float long double inc dec
                             zero? min max true? false?])
   (:require [primitive-math :refer :all]


### PR DESCRIPTION
This should fix the warning I get when using the clj-uuid
```
WARNING: unsigned-bit-shift-right already refers to: #'clojure.core/unsigned-bit-shift-right in namespace: clj-uuid.bi
tmop, being replaced by: #'primitive-math/unsigned-bit-shift-right 
```