### PR TITLE
Exclude `unsigned-bit-shift-right` to prevent warnings

### DIFF
--- a/src/clj_uuid/bitmop.clj
+++ b/src/clj_uuid/bitmop.clj
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [* + - / < > <= >= == rem bit-or bit-and bit-xor
                             bit-not bit-shift-left bit-shift-right
                             byte short int float long double inc dec
-                            zero? min max true? false?])
+                            zero? min max true? false? unsigned-bit-shift-right])
   (:require [primitive-math :refer :all]
             [clojure.pprint :refer [cl-format pprint]]
             [clj-uuid.constants :refer :all]


### PR DESCRIPTION
I get 

```
WARNING: unsigned-bit-shift-right already refers to: #'clojure.core/unsigned-bit-shift-right in namespace: clj-uuid.bitmop, being replaced by: #'primitive-math/unsigned-bit-shift-right
```

currently; I tried but failed to convince myself that this was the result of a recent change. Maybe the warnings were added recently, I don't know, but that function was added to core in 1.6 and that's the version of clojure mentioned in clj-uuid's project.clj.