### PR TITLE
Fix shadowing warning

### DIFF
--- a/src/clj_uuid/bitmop.clj
+++ b/src/clj_uuid/bitmop.clj
@@ -1,6 +1,7 @@
 (ns clj-uuid.bitmop
   (:refer-clojure :exclude [* + - / < > <= >= == rem bit-or bit-and bit-xor
-                            bit-not bit-shift-left bit-shift-right
+                            bit-not bit-shift-left bit-shift-right 
+                            unsigned-bit-shift-right
                             byte short int float long double inc dec
                             zero? min max true? false?])
   (:require [primitive-math :refer :all]


### PR DESCRIPTION
Fixes `WARNING: unsigned-bit-shift-right already refers to: #'clojure.core/unsigned-bit-shift-right in namespace: clj-uuid.bitmop, being replaced by: #'primitive-math/unsigned-bit-shift-right`

as per https://github.com/ztellman/primitive-math/blob/master/src/primitive_math.clj#L3