### PR TITLE
Make `+node-id+` a delay

### DIFF
--- a/src/clj_uuid/node.clj
+++ b/src/clj_uuid/node.clj
@@ -34,11 +34,11 @@
 ;;  node       |    6 |  ub48   |  (<BYTE> <BYTE> <BYTE> <BYTE> <BYTE> <BYTE>)
 ;;
 ;; prepending two other (computed) bytes to the node-id before
-;; bitwise assembly.  
-;; 
-;;  (cons clock-high (cons clock-low (+node-id+)))
+;; bitwise assembly.
 ;;
-;;  
+;;  (cons clock-high (cons clock-low @+node-id+))
+;;
+;;
 ;;      ( <BYTE> . <BYTE> . <BYTE> <BYTE> <BYTE> <BYTE> <BYTE> <BYTE>)
 ;;
 
@@ -50,18 +50,18 @@
 ;; approaches.  The most straightforward is the use of IEEE 802 MAC Address:
 ;;
 ;;     (.getHardwareAddress
-;;       (java.net.NetworkInterface/getByInetAddress 
+;;       (java.net.NetworkInterface/getByInetAddress
 ;;         (java.net.InetAddress/getLocalHost))))))
 ;;
 ;; Unfortunately got reports of NPE on some platforms (openjdk?).  Also, it
-;; discloses the hardware address of the host system -- this is how the 
+;; discloses the hardware address of the host system -- this is how the
 ;; creator of the melissa virus was actually tracked down and caught.
 ;;
 ;; choosing node-id randomly does not provide consistent generation of UUID's
 ;; across runtimes.
 ;;
 ;; This topic is specifically addressed by the RFC:
-;; 
+;;
 ;;
 ;;   "A better solution is to obtain a 47-bit cryptographic quality random
 ;;   number and use it as the low 47-bits of the Node-ID, with the least
@@ -87,16 +87,16 @@
 ;; We do exactly that.  Taking into account that the term "first octet"
 ;; in the above excerpt refers to network transmission order, and we
 ;; 'bit-or' the corresponding bytes:
-;;                                                      
+;;
 ;;     hi-byte | byte5 | byte4 | byte3 | byte2 | lo-byte
 ;;    ---------+-------+-------+-------+-------+---------
-;;       0x00  |  0x00 |  0x00 |  0x00 |  0x00 |   0x01      
-;;                                                      
+;;       0x00  |  0x00 |  0x00 |  0x00 |  0x00 |   0x01
+;;
 ;; Thanks to Datastax and to @jjcomer for submitting the original patch
 ;; from which this current implementation is largely derived.
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
- 
+
 
 (def ^:private datasources ["java.vendor"
                             "java.vendor.url"
@@ -115,7 +115,7 @@
                                                   (.getInetAddresses ni)))))
                              base-addresses
                              (enumeration-seq
-                               (NetworkInterface/getNetworkInterfaces)))]    
+                               (NetworkInterface/getNetworkInterfaces)))]
     (reduce conj network-interfaces
       (map str (InetAddress/getAllByName host-name)))))
 
@@ -142,14 +142,12 @@
 
 (def node-id make-node-id)
 
-(defn +node-id+
-  []
-  (assemble-bytes (cons 0 (cons 0 (node-id)))))
+(def +node-id+ (delay (assemble-bytes (cons 0 (cons 0 (node-id)))))
 
 (defn- +v1-lsb+'
   []
   (let [clk-high  (dpb (mask 2 6) (ldb (mask 6 8) +clock-sequence+) 0x2)
         clk-low   (ldb (mask 8 0) +clock-sequence+)]
-    (dpb (mask 8 56) (dpb (mask 8 48) (+node-id+) clk-low) clk-high)))
+    (dpb (mask 8 56) (dpb (mask 8 48) @+node-id+ clk-low) clk-high)))
 
 (def +v1-lsb+ (memoize +v1-lsb+'))

--- a/src/clj_uuid/node.clj
+++ b/src/clj_uuid/node.clj
@@ -142,7 +142,7 @@
 
 (def node-id make-node-id)
 
-(def +node-id+ (delay (assemble-bytes (cons 0 (cons 0 (node-id)))))
+(def +node-id+ (delay (assemble-bytes (cons 0 (cons 0 (node-id))))))
 
 (defn- +v1-lsb+'
   []

--- a/test/clj_uuid/node_test.clj
+++ b/test/clj_uuid/node_test.clj
@@ -9,7 +9,5 @@
   (is (coll? (node-id)))
   (is (= 6 (count (node-id))))
   (is (every? number? (node-id)))
-  (is (= 1 (bit-and 0x01 (+node-id+))))
-  (is (instance? Long (+node-id+))))
- 
-
+  (is (= 1 (bit-and 0x01 @+node-id+)))
+  (is (instance? Long @+node-id+)))


### PR DESCRIPTION
This makes `+node-id+` into a delay, alleviating pressure on the garbage collector instead of being repeatedly called as a function. See discussion in https://github.com/danlentz/clj-uuid/pull/40.