### PR TITLE
update primitive math dep, and fix reflection call to alength

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -2,9 +2,9 @@ name: Clojure CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
 
 jobs:
   build:

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -2,7 +2,8 @@ name: Clojure CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches:
+      - "*"
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -1,0 +1,27 @@
+name: Clojure CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        # see: https://github.com/marketplace/actions/setup-java
+        distribution: 'corretto'
+        java-version: '8'
+    - name: Install clojure tools
+      uses: DeLaGuardo/setup-clojure@12.1
+      with:
+        # see: https://github.com/marketplace/actions/setup-clojure
+        cli: 1.11.1.1429
+    - name: Run tests
+      run: lein test

--- a/project.clj
+++ b/project.clj
@@ -11,11 +11,12 @@
   :signing  {:gpg-key "7FD20410"}
   :url          "https://github.com/danlentz/clj-uuid"
   :license      {:name "Eclipse Public License"
-                  :url "http://www.eclipse.org/legal/epl-v10.html"}
+                 :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1" :scope "provided"]
-                 [primitive-math      "0.1.6"]]
+                 [org.clj-commons/primitive-math "1.0.1"]]
+
   :codox    {:output-dir  "doc/api"
              :src-dir-uri "https://github.com/danlentz/clj-uuid/blob/master/"
              :src-linenum-anchor-prefix "L"
              :project {:name "clj-uuid"}}
-  :global-vars {*warn-on-reflection* false})
+  :global-vars {*warn-on-reflection* true})

--- a/src/clj_uuid.clj
+++ b/src/clj_uuid.clj
@@ -708,7 +708,7 @@
     (let [bb (ByteBuffer/wrap ba)]
       (UUID. (.getLong bb) (.getLong bb))))
   (uuidable? [^bytes ba]
-    (= 16 (alength ba)))
+    (= 16 (alength ^bytes ba)))
 
   String
   (uuidable? ^boolean [s]


### PR DESCRIPTION
Hi, I'd like to contribute the following changes:
- update primitive math dep to latest version.
- update call to alength to include type hint to avoid reflection call.
- turn on warn on reflection.
- add github actions CI (I can remove this, but Travis is not triggering so good idea?)