### PR TITLE
Add uuids v6, v7, and v8 draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,9 @@ _(function)_    `v0 []`
 
 > Return the null UUID, #uuid "00000000-0000-0000-0000-000000000000"
 
+_(function)_    `max []`
+
+> Return the maximum UUID, #uuid "ffffffff-ffff-ffff-ffff-ffffffffffff"
 
 _(function)_    `v1 []`
 
@@ -620,6 +623,30 @@ _(function)_    `v5 [^UUID namespace ^Object local-name]`
 >  * If two v5 UUID's are equal, then there is a high degree of certainty
 >    that they were generated from the same name in the same namespace.
 
+_(function)_    `v6 []`
+
+> Generate a v6 (time-based), lexically sortable, unique identifier,
+> guaranteed to be unique and thread-safe regardless of clock
+> precision or degree of concurrency.  Creation of v6 UUID's does not
+> require any call to a cryptographic generator and can be
+> accomplished much more efficiently than v3, v4, v5, or squuid's.  A
+> v6 UUID reveals both the identity of the computer that generated the
+> UUID and the time at which it did so.  Its uniqueness across
+> computers is guaranteed as long as MAC addresses are not
+> duplicated. Used for compatibility with systems that already use v1;
+> UUID v7 should be prefered over v1 or v6.
+
+_(function)_    `v7 []`
+
+> Generate a v7 unix time-based, lexically sortable UUID with monotonic
+> counter and cryptographically secure random portion. The 12 bit
+> rand_a is used as counter, rand_b is CSPRNG. Random numbers are
+> generated using the JVM default implementation of
+> java.security.SecureRandom.
+
+_(function)_    `v8 [^long msb, ^long lsb]`
+
+> Generate a v8 custom UUID with up to 122 bits of user data.
 
 _(function)_    `squuid []`
 
@@ -631,6 +658,35 @@ _(function)_    `squuid []`
 >  time (seconds since 12:00am January 1, 1970 UTC) with the most
 >  significant 32 bits of the UUID
 
+_(function)_    `= [x]`
+
+_(function)_    `= [x y]`
+
+_(function)_    `= [x y & more]`
+
+> Directly compare two or more UUIDs for = relation based on the
+> ordinality semantics defined by [RFC4122:3 RULES FOR LEXICAL
+> EQUIVALENCE].
+
+_(function)_    `> [x]`
+
+_(function)_    `> [x y]`
+
+_(function)_    `> [x y & more]`
+
+> Directly compare two or more UUIDs for > relation based on the
+> ordinality semantics defined by [RFC4122:3 RULES FOR LEXICAL
+> EQUIVALENCE].
+
+_(function)_    `< [x]`
+
+_(function)_    `< [x y]`
+
+_(function)_    `< [x y & more]`
+
+> Directly compare two or more UUIDs for < relation based on the
+> ordinality semantics defined by [RFC4122:3 RULES FOR LEXICAL
+> EQUIVALENCE].
 
 _(function)_    `monotonic-time []`
 

--- a/src/clj_uuid.clj
+++ b/src/clj_uuid.clj
@@ -362,7 +362,7 @@
 
   (uuid? ^boolean [_] true)
 
-  (uuid= ^boolean [^UUID x ^UUID y & more]
+  (uuid= ^boolean [^UUID x ^UUID y]
     (.equals x y))
 
   (uuid< ^boolean [^UUID x ^UUID y]

--- a/src/clj_uuid.clj
+++ b/src/clj_uuid.clj
@@ -74,7 +74,7 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; UUID Variant                                     [RFC4122:4.1.1 "VARIANT"] ;;
+;; UUID Variant                                                 [RFC9562:4.1] ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; The variant indicates the layout of the UUID. The UUID specification
@@ -90,14 +90,14 @@
 ;;
 ;; the most significant bits of N indicate the variant (depending on the
 ;; variant one, two, or three bits are used). The variant covered by the
-;; RFC4122 is indicated by the two most significant bits of N being 1 0
+;; RFC9562 is indicated by the two most significant bits of N being 1 0
 ;; (i.e., the hexadecimal N will always be 8, 9, A, or B).
 ;;
 
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; UUID Version                                     [RFC4122:4.1.3 "VERSION"] ;;
+;; UUID Version                                                 [RFC9562:4.2] ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; The Leach-Salz UUID variant has five defined versions. In the canonical
@@ -112,7 +112,7 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; The NULL (variant 0) UUID                       [RFC4122:4.1.7 "NIL UUID"] ;;
+;; The NULL (variant 0) UUID                                    [RFC9562:5.9] ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; "The [null] UUID is a special form of UUID that is specified to have
@@ -124,7 +124,7 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; The MAX UUID                                   [RFC4122:5.4    "MAX UUID"] ;;
+;; The MAX UUID                                                [RFC9562:5.10] ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; "The [max] UUID is a special form of UUID that is specified to have
@@ -139,7 +139,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; The following UUID's are the canonical top-level namespace identifiers
-;; defined in RFC4122 Appendix C.
+;; defined in RFC9562 Appendix C.
 
 
 (def ^:const +namespace-dns+  #uuid "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
@@ -193,9 +193,9 @@
 
 
 
-(defprotocol UUIDRfc4122
+(defprotocol UUIDRfc9562
   "A protocol that abstracts an unique identifier as described by
-  IETF RFC4122 <http://www.ietf.org/rfc/rfc4122.txt>. A UUID
+  IETF RFC9562 <http://www.ietf.org/rfc/rfc9562.txt>. A UUID
   represents a 128-bit value, however there are variant encoding
   layouts used to assign and interpret information encoded in
   those bits.  This is a protocol for  _variant 2_ (*Leach-Salz*)
@@ -214,7 +214,7 @@
     therefore equal to the maximum UUID, ffffffff-ffff-ffff-ffff-ffffffffffff.")
 
   (uuid?                         [x]
-    "Return `true` if `x` implements an RFC4122 unique identifier.")
+    "Return `true` if `x` implements an RFC9562 unique identifier.")
 
   (uuid=                         [x y]
     "Directly compare two UUID's for = relation based on the equality
@@ -266,7 +266,7 @@
 
     In the canonical representation, xxxxxxxx-xxxx-xxxx-Nxxx-xxxxxxxxxxxx,
     the most significant bits of N indicate the variant (depending on the
-    variant one, two, or three bits are used). The variant covered by RFC4122
+    variant one, two, or three bits are used). The variant covered by RFC9562
     is indicated by the two most significant bits of N being 1 0 (i.e., the
     hexadecimal N will always be 8, 9, A, or B).")
 
@@ -344,9 +344,11 @@
     "Return the unique URN URI associated with this UUID."))
 
 
+;; For backwards compatibility
+(def UUIDRfc4122 UUIDRfc9562)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; RFC4122 Unique Identifier extended java.util.UUID
+;; RFC9562 Unique Identifier extended java.util.UUID
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
@@ -358,7 +360,7 @@
   (uuidable? [_] true)
 
 
-  UUIDRfc4122
+  UUIDRfc9562
 
   (uuid? ^boolean [_] true)
 
@@ -473,7 +475,7 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; V0 UUID Constructor                             [RFC4122:4.1.7 "NIL UUID"] ;;
+;; V0 UUID Constructor                                          [RFC9562:5.9] ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn null
@@ -489,7 +491,7 @@
   +null+)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; The MAX UUID Constructor                       [RFC4122:5.4    "MAX UUID"] ;;
+;; The MAX UUID Constructor                                    [RFC9562:5.10] ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn max
@@ -501,7 +503,7 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; V1 UUID Constructor                   [RFC4122:4.2.2 "GENERATION DETAILS"] ;;
+;; V1, V6 UUID Constructors                                [RFC9562:5.1, 5.6] ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Concatenate the UUID version with the MAC address of the computer that is
@@ -554,7 +556,7 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; V4 (random) UUID Constructor     [RFC4122:4.4 "ALGORITHM FOR CREATING..."] ;;
+;; V4 (random) UUID Constructor                                 [RFC9562:5.4] ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn v4
@@ -674,7 +676,7 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Namespaced UUIDs [RFC4122:4.3  "ALGORITHM FOR CREATING A NAME BASED UUID"] ;;
+;; Namespaced UUIDs                                        [RFC9562:5.3, 5.5] ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn v3
@@ -730,7 +732,7 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Lexically Sortable UUID                       [RFC4122:5.2: UUID Version 7];;
+;; Lexically Sortable UUID                       [RFC9562:5.7: UUID Version 7];;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn v7
@@ -749,7 +751,7 @@
     (UUID. msb lsb)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Custom UUID                                   [RFC4122:5.2: UUID Version 8];;
+;; Custom UUID                                   [RFC9562:5.8: UUID Version 8];;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn v8
@@ -826,7 +828,7 @@
     (uuid-urn-string? s) (UUID/fromString (subs s 9))
     :else                (exception "invalid UUID")))
 
-(extend-protocol UUIDRfc4122
+(extend-protocol UUIDRfc9562
   Object
   (uuid? [x] false)
 

--- a/src/clj_uuid.clj
+++ b/src/clj_uuid.clj
@@ -297,8 +297,9 @@
     might be generated under unusual situations, such as if the system hardware
     clock is set backward in time or if, despite all efforts otherwise, a
     duplicate node-id happens to be generated. This value is initialized to
-    a random 16-bit number once per lifetime of the system.  For non-gregorian,
-    time-based (v3, v4, v5, v7, v8, squuid) UUID's, always returns `nil`.")
+    a random 16-bit number once per lifetime of the system.  For
+    non-gregorian-time-based (v3, v4, v5, v7, v8, squuid) UUID's, always
+    returns `nil`.")
 
   (get-node-id                   [uuid]
     "Return the 48 bit unsigned value that represents the spatially unique
@@ -309,7 +310,7 @@
     timestamp associated with this UUID.  For time-based (v1, v6) UUID's the
     result encodes the number of 100 nanosecond intervals since the
     adoption of the Gregorian calendar: 12:00am Friday October 15, 1582 UTC.
-    For non-gregorian, time-based (v3, v4, v5, v7, v8, squuid) UUID's, always
+    For non-gregorian-time-based (v3, v4, v5, v7, v8, squuid) UUID's, always
     returns `nil`.")
 
   (get-instant   ^java.util.Date [uuid]

--- a/src/clj_uuid.clj
+++ b/src/clj_uuid.clj
@@ -550,9 +550,9 @@
   guaranteed to be unique and thread-safe regardless of clock
   precision or degree of concurrency.  Creation of v6 UUID's does not
   require any call to a cryptographic generator and can be
-  accomplished much more efficiently than v3, v4, v5, or squuid's.  A
-  v6 UUID reveals both the identity of the computer that generated the
-  UUID and the time at which it did so.  Its uniqueness across
+  accomplished much more efficiently than v3, v4, v5, v7, or squuid's.
+  A v6 UUID reveals both the identity of the computer that generated
+  the UUID and the time at which it did so.  Its uniqueness across
   computers is guaranteed as long as MAC addresses are not
   duplicated. Used for compatibility with systems that already use v1;
   UUID v7 should be prefered over v1 or v6."

--- a/src/clj_uuid.clj
+++ b/src/clj_uuid.clj
@@ -455,7 +455,8 @@
   (get-timestamp ^long [uuid]
     (case (.version uuid)
       1 (.timestamp uuid)
-      6 (bit-or (get-time-low uuid)
+      6 (bit-or (bitmop/ldb #=(bitmop/mask 12 0)
+                            (.getMostSignificantBits uuid))
                 (bit-shift-left (get-time-mid uuid) 12)
                 (bit-shift-left (get-time-high uuid) 28))
       nil))

--- a/src/clj_uuid/constants.clj
+++ b/src/clj_uuid/constants.clj
@@ -23,5 +23,3 @@
 (def ^:const +ub8-mask+  0x00000000000000ff)
 (def ^:const +ub4-mask+  0x000000000000000f)
 (def ^:const +ub1-mask+  0x0000000000000001)
-
-(def ^:const +max-counter+ 0xfff)

--- a/src/clj_uuid/constants.clj
+++ b/src/clj_uuid/constants.clj
@@ -23,3 +23,5 @@
 (def ^:const +ub8-mask+  0x00000000000000ff)
 (def ^:const +ub4-mask+  0x000000000000000f)
 (def ^:const +ub1-mask+  0x0000000000000001)
+
+(def ^:const +max-counter+ 0xfff)

--- a/src/clj_uuid/random.clj
+++ b/src/clj_uuid/random.clj
@@ -1,0 +1,26 @@
+(ns clj-uuid.random
+  (:require [clj-uuid.bitmop :as bitmop])
+  (:import (java.security SecureRandom))
+  (:refer-clojure :exclude [bytes long]))
+
+(defonce ^:private secure-random
+  (delay (SecureRandom.)))
+
+(defn bytes
+  "Generate `n` random bytes."
+  [n]
+  (let [bs (byte-array n)]
+    (.nextBytes ^SecureRandom @secure-random bs)
+    bs))
+
+(defn long
+  "Generate a long value that is hard to guess. limited to the number of bytes."
+  ([]
+   (long 8))
+  ([n-bytes]
+   (reduce (fn [n b] (+ (bit-shift-left n 8) b)) 0 (bytes n-bytes))))
+
+(defn long-12bit
+  "Generate a long value between 0 and 512"
+  []
+  (bit-and (long 2) 0xfff))

--- a/src/clj_uuid/random.clj
+++ b/src/clj_uuid/random.clj
@@ -23,4 +23,4 @@
 (defn long-12bit
   "Generate a long value between 0 and 512"
   []
-  (bit-and (long 2) 0xfff))
+  (bit-and (long 3) 0xfff))

--- a/src/clj_uuid/util.clj
+++ b/src/clj_uuid/util.clj
@@ -14,7 +14,7 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; PROG1 but with more idiomatic clojure name 
+;; PROG1 but with more idiomatic clojure name
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defmacro returning
@@ -35,7 +35,7 @@
 
 (defmacro compile-if
   "Evaluate `exp` and if it returns logical true and doesn't error, expand to
-  `then` otherwise expand to `else`.  
+  `then` otherwise expand to `else`.
   credit: <clojure/src/clj/clojure/core/reducers.clj#L24>
 
   (compile-if (Class/forName \"java.util.concurrent.ForkJoinTask\")
@@ -76,13 +76,13 @@
 
 (defmacro wrap-fn [name args & body]
   `(let [old-fn# (var-get (var ~name))
-         new-fn# (fn [& p#] 
-                   (let [~args p#] 
+         new-fn# (fn [& p#]
+                   (let [~args p#]
                      (do ~@body)))
          wrapper# (fn [& params#]
                     (if (= ~(count args) (count params#))
                       (apply new-fn# params#)
-                      (apply old-fn# params#)))] 
+                      (apply old-fn# params#)))]
      (alter-var-root (var ~name) (constantly wrapper#))))
 
 
@@ -110,7 +110,7 @@
 ;; Condition Handling
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defmacro exception [& [param & more :as params]] 
-  (if (class? param) 
-    `(throw (new ~param (str ~@(interpose " " more)))) 
+(defmacro exception [& [param & more :as params]]
+  (if (class? param)
+    `(throw (new ~param (str ~@(interpose " " more))))
     `(throw (Exception. (str ~@(interpose " " params))))))

--- a/test/clj_uuid/api_test.clj
+++ b/test/clj_uuid/api_test.clj
@@ -29,7 +29,8 @@
       (is (= (get-clk-low tmpid)        0))
       (is (= (get-clk-high tmpid)       0))
       (is (= (get-node-id tmpid)        0))
-      (is (= (get-timestamp tmpid)      nil))))
+      (is (= (get-timestamp tmpid)      nil))
+      (is (= (get-unix-time tmpid)      nil))))
 
   (testing "v1 uuid protocol..."
     (let [tmpid +namespace-x500+]
@@ -51,7 +52,8 @@
       (is (= (get-clk-low tmpid)        128))
       (is (= (get-clk-high tmpid)       180))
       (is (= (get-node-id tmpid)        825973027016))
-      (is (= (get-timestamp tmpid)      131059232331511828))))
+      (is (= (get-timestamp tmpid)      131059232331511828))
+      (is (= (get-unix-time tmpid)      886630433151))))
 
   (testing "v3 uuid protocol..."
     (let [tmpid (java.util.UUID/fromString
@@ -74,7 +76,8 @@
       (is (= (get-clk-low tmpid)         181))
       (is (= (get-clk-high tmpid)        173))
       (is (= (get-node-id tmpid)         242869739581566))
-      (is (= (get-timestamp tmpid)       nil))))
+      (is (= (get-timestamp tmpid)       nil))
+      (is (= (get-unix-time tmpid)       nil))))
 
   (testing "v4 uuid protocol..."
     (let [tmpid #uuid "3eb1e29a-4747-4a7d-8e40-94e245f57dc0"]
@@ -96,7 +99,8 @@
       (is (= (get-clk-low tmpid)         142))
       (is (= (get-clk-high tmpid)        64))
       (is (= (get-node-id tmpid)         163699557236160))
-      (is (= (get-timestamp tmpid)       nil))))
+      (is (= (get-timestamp tmpid)       nil))
+      (is (= (get-unix-time tmpid)       nil))))
 
   (testing "max uuid protocol..."
     (let [tmpid +max+]
@@ -118,7 +122,8 @@
       (is (= (get-clk-low tmpid)        0xff))
       (is (= (get-clk-high tmpid)       0xff))
       (is (= (get-node-id tmpid)        0xffffffffffff))
-      (is (= (get-timestamp tmpid)      nil))))
+      (is (= (get-timestamp tmpid)      nil))
+      (is (= (get-unix-time tmpid)      nil))))
 
   (testing "v6 uuid protocol..."
     (let [tmpid #uuid "1ef3f06f-16db-6ff0-bb01-1b50e6f39e7f"]
@@ -140,7 +145,8 @@
       (is (= (get-clk-low tmpid)        0xbb))
       (is (= (get-clk-high tmpid)       0x1))
       (is (= (get-node-id tmpid)        0x1b50e6f39e7f))
-      (is (= (get-timestamp tmpid)      0x1ef3f06f16dbff0))))
+      (is (= (get-timestamp tmpid)      0x1ef3f06f16dbff0))
+      (is (= (get-unix-time tmpid)      1720648452463))))
 
   (testing "v7 uuid protocol..."
     (let [tmpid #uuid "01909eae-4801-753a-bcd5-0889c34ac129"]
@@ -162,7 +168,8 @@
       (is (= (get-clk-low tmpid)        0xbc))
       (is (= (get-clk-high tmpid)       0xd5))
       (is (= (get-node-id tmpid)        0x0889c34ac129))
-      (is (= (get-timestamp tmpid)      nil))))
+      (is (= (get-timestamp tmpid)      nil))
+      (is (= (get-unix-time tmpid)      0x01909eae4801))))
 
   (testing "v8 uuid protocol..."
     (let [tmpid #uuid "ffffffff-ffff-8fff-bfff-ffffffffffff"]
@@ -184,7 +191,8 @@
       (is (= (get-clk-low tmpid)        0xbf))
       (is (= (get-clk-high tmpid)       0xff))
       (is (= (get-node-id tmpid)        0xffffffffffff))
-      (is (= (get-timestamp tmpid)      nil)))))
+      (is (= (get-timestamp tmpid)      nil))
+      (is (= (get-unix-time tmpid)      nil)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Predicate Tests

--- a/test/clj_uuid/api_test.clj
+++ b/test/clj_uuid/api_test.clj
@@ -1,7 +1,7 @@
 (ns clj-uuid.api-test
-  (:refer-clojure :exclude [uuid?])
+  (:refer-clojure :exclude [uuid? max])
   (:require [clojure.test :refer :all]
-            [clj-uuid     :refer :all])
+            [clj-uuid     :refer :all :exclude [= > <]])
   (:import
    (java.lang IllegalArgumentException)))
 
@@ -77,8 +77,7 @@
       (is (= (get-timestamp tmpid)       nil))))
 
   (testing "v4 uuid protocol..."
-    (let [tmpid
-          (java.util.UUID/fromString "3eb1e29a-4747-4a7d-8e40-94e245f57dc0")]
+    (let [tmpid #uuid "3eb1e29a-4747-4a7d-8e40-94e245f57dc0"]
       (is (= (get-word-high tmpid)       4517641053478013565))
       (is (= (get-word-low tmpid)       -8196387622257066560))
       (is (= (null? tmpid)               false))
@@ -97,9 +96,95 @@
       (is (= (get-clk-low tmpid)         142))
       (is (= (get-clk-high tmpid)        64))
       (is (= (get-node-id tmpid)         163699557236160))
-      (is (= (get-timestamp tmpid)       nil)))))
+      (is (= (get-timestamp tmpid)       nil))))
 
+  (testing "max uuid protocol..."
+    (let [tmpid +max+]
+      (is (= (get-word-high tmpid)       -1))
+      (is (= (get-word-low tmpid)        -1))
+      (is (= (null? tmpid)               false))
+      (is (= (max? tmpid)                true))
+      (is (= (seq (to-byte-array tmpid)) [-1 -1 -1 -1 -1 -1 -1 -1
+                                          -1 -1 -1 -1 -1 -1 -1 -1]))
+      (is (= (hash-code tmpid)           0))
+      (is (= (get-version tmpid)         0xf))
+      (is (= (to-string tmpid)       "ffffffff-ffff-ffff-ffff-ffffffffffff"))
+      (is (=
+            (to-urn-string tmpid)
+            "urn:uuid:ffffffff-ffff-ffff-ffff-ffffffffffff"))
+      (is (= (get-time-low tmpid)       0xffffffff))
+      (is (= (get-time-mid tmpid)       0xffff))
+      (is (= (get-time-high tmpid)      0xffff))
+      (is (= (get-clk-low tmpid)        0xff))
+      (is (= (get-clk-high tmpid)       0xff))
+      (is (= (get-node-id tmpid)        0xffffffffffff))
+      (is (= (get-timestamp tmpid)      nil))))
 
+  (testing "v6 uuid protocol..."
+    (let [tmpid #uuid "1ef3f06f-16db-6ff0-bb01-1b50e6f39e7f"]
+      (is (= (get-word-high tmpid)       2230390600394043376))
+      (is (= (get-word-low tmpid)        -4971662479354257793))
+      (is (= (null? tmpid)               false))
+      (is (= (max? tmpid)                false))
+      (is (= (seq (to-byte-array tmpid)) [30  -13 -16 111 22  -37 111 -16
+                                          -69 1   27  80  -26 -13 -98 127]))
+      (is (= (hash-code tmpid)           1440357040))
+      (is (= (get-version tmpid)         6))
+      (is (= (to-string tmpid)       "1ef3f06f-16db-6ff0-bb01-1b50e6f39e7f"))
+      (is (=
+            (to-urn-string tmpid)
+            "urn:uuid:1ef3f06f-16db-6ff0-bb01-1b50e6f39e7f"))
+      (is (= (get-time-low tmpid)       0x6ff0))
+      (is (= (get-time-mid tmpid)       0x16db))
+      (is (= (get-time-high tmpid)      0x1ef3f06f))
+      (is (= (get-clk-low tmpid)        0xbb))
+      (is (= (get-clk-high tmpid)       0x1))
+      (is (= (get-node-id tmpid)        0x1b50e6f39e7f))
+      (is (= (get-timestamp tmpid)      0x1ef3f06f16dfff0))))
+
+  (testing "v7 uuid protocol..."
+    (let [tmpid #uuid "01909eae-4801-753a-bcd5-0889c34ac129"]
+      (is (= (get-word-high tmpid)       112764462053815610))
+      (is (= (get-word-low tmpid)        -4839952836759731927))
+      (is (= (null? tmpid)               false))
+      (is (= (max? tmpid)                false))
+      (is (= (seq (to-byte-array tmpid)) [1   -112 -98 -82  72  1  117 58
+                                          -68 -43  8   -119 -61 74 -63 41]))
+      (is (= (hash-code tmpid)           906895924))
+      (is (= (get-version tmpid)         7))
+      (is (= (to-string tmpid)       "01909eae-4801-753a-bcd5-0889c34ac129"))
+      (is (=
+            (to-urn-string tmpid)
+            "urn:uuid:01909eae-4801-753a-bcd5-0889c34ac129"))
+      (is (= (get-time-low tmpid)       0x01909eae))
+      (is (= (get-time-mid tmpid)       0x4801))
+      (is (= (get-time-high tmpid)      0x753a))
+      (is (= (get-clk-low tmpid)        0xbc))
+      (is (= (get-clk-high tmpid)       0xd5))
+      (is (= (get-node-id tmpid)        0x0889c34ac129))
+      (is (= (get-timestamp tmpid)      nil))))
+
+  (testing "v8 uuid protocol..."
+    (let [tmpid #uuid "ffffffff-ffff-8fff-bfff-ffffffffffff"]
+      (is (= (get-word-high tmpid)       -28673))
+      (is (= (get-word-low tmpid)        -4611686018427387905))
+      (is (= (null? tmpid)               false))
+      (is (= (max? tmpid)                false))
+      (is (= (seq (to-byte-array tmpid)) [-1  -1 -1 -1 -1 -1 -113 -1
+                                          -65 -1 -1 -1 -1 -1 -1   -1]))
+      (is (= (hash-code tmpid)           1073770496))
+      (is (= (get-version tmpid)         8))
+      (is (= (to-string tmpid)       "ffffffff-ffff-8fff-bfff-ffffffffffff"))
+      (is (=
+            (to-urn-string tmpid)
+            "urn:uuid:ffffffff-ffff-8fff-bfff-ffffffffffff"))
+      (is (= (get-time-low tmpid)       0xffffffff))
+      (is (= (get-time-mid tmpid)       0xffff))
+      (is (= (get-time-high tmpid)      0x8fff))
+      (is (= (get-clk-low tmpid)        0xbf))
+      (is (= (get-clk-high tmpid)       0xff))
+      (is (= (get-node-id tmpid)        0xffffffffffff))
+      (is (= (get-timestamp tmpid)      nil)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Predicate Tests

--- a/test/clj_uuid/api_test.clj
+++ b/test/clj_uuid/api_test.clj
@@ -140,7 +140,7 @@
       (is (= (get-clk-low tmpid)        0xbb))
       (is (= (get-clk-high tmpid)       0x1))
       (is (= (get-node-id tmpid)        0x1b50e6f39e7f))
-      (is (= (get-timestamp tmpid)      0x1ef3f06f16dfff0))))
+      (is (= (get-timestamp tmpid)      0x1ef3f06f16dbff0))))
 
   (testing "v7 uuid protocol..."
     (let [tmpid #uuid "01909eae-4801-753a-bcd5-0889c34ac129"]

--- a/test/clj_uuid/clock_test.clj
+++ b/test/clj_uuid/clock_test.clj
@@ -27,21 +27,38 @@
               (map #(apply < %) answers)))))))
 
 
+(deftest check-monotonic-unix-time-and-random-counter
+  (doseq [concur (range 5 9)]
+    (let [extent  100000
+          agents  (map agent (repeat concur nil))
+          working (map #(send-off %
+                          (fn [state]
+                            (repeatedly extent
+                                        monotonic-unix-time-and-random-counter)))
+                         agents)
+          _       (apply await working)
+          answers (map deref working)]
+      (testing "single-thread timestamp uniqueness..."
+        (is (=
+              (* concur extent)
+              (apply + (map (comp count set) answers)))))
+      (testing "concurrent timestamp uniqueness..."
+        (is (=
+              (* concur extent)
+              (count (apply clojure.set/union (map set answers))))))
+      (testing "concurrent monotonic increasing..."
+        (doseq [answer answers]
+          (let [[time counter] (first answer)]
+            (loop [time    time
+                   counter counter
+                   more    (rest answer)]
+              (when-let [[next-time next-counter] (first more)]
+                (cond
+                  (< next-time time)
+                  (is false "time must be increasing")
 
+                  (and (= next-time time) (<= next-counter counter))
+                  (is false "counter must be increasing")
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+                  :else
+                  (recur next-time next-counter (rest more)))))))))))

--- a/test/clj_uuid/v1_test.clj
+++ b/test/clj_uuid/v1_test.clj
@@ -1,8 +1,8 @@
 (ns clj-uuid.v1-test
+  "Time based UUIDs tests"
   (:require [clojure.test   :refer :all]
             [clojure.set]
-            [clj-uuid :refer [v1 get-timestamp]]))
-
+            [clj-uuid :as uuid :refer [v7 v6 v1 get-timestamp]]))
 
 (deftest check-v1-concurrency
   (doseq [concur (range 5 9)]
@@ -25,3 +25,47 @@
       (testing "concurrent v1 monotonic increasing..."
         (is (every? identity
               (map #(apply < (map get-timestamp %)) answers)))))))
+
+(deftest check-v6-concurrency
+  (doseq [concur (range 5 9)]
+    (let [extent    100000
+          agents    (map agent (repeat concur nil))
+          working   (map #(send-off %
+                            (fn [state]
+                              (repeatedly extent v6)))
+                      agents)
+          _         (apply await working)
+          answers   (map deref working)]
+      (testing "single-thread v6 uuid uniqueness..."
+        (is (=
+              (* concur extent)
+              (apply + (map (comp count set) answers)))))
+      (testing "concurrent v6 uuid uniqueness..."
+        (is (=
+              (* concur extent)
+              (count (apply clojure.set/union (map set answers))))))
+      (testing "concurrent v6 monotonic increasing..."
+        (is (every? identity
+              (map uuid/< answers)))))))
+
+(deftest check-v7-concurrency
+  (doseq [concur (range 5 9)]
+    (let [extent    100000
+          agents    (map agent (repeat concur nil))
+          working   (map #(send-off %
+                            (fn [state]
+                              (repeatedly extent v7)))
+                      agents)
+          _         (apply await working)
+          answers   (map deref working)]
+      (testing "single-thread v7 uuid uniqueness..."
+        (is (=
+              (* concur extent)
+              (apply + (map (comp count set) answers)))))
+      (testing "concurrent v7 uuid uniqueness..."
+        (is (=
+              (* concur extent)
+              (count (apply clojure.set/union (map set answers))))))
+      (testing "concurrent v7 monotonic increasing..."
+        (is (every? identity
+              (map uuid/< answers)))))))

--- a/test/clj_uuid/v3_test.clj
+++ b/test/clj_uuid/v3_test.clj
@@ -1,7 +1,7 @@
 (ns clj-uuid.v3-test
-  (:refer-clojure :exclude [uuid?])
+  (:refer-clojure :exclude [uuid? max])
   (:require [clojure.test   :refer :all]
-            [clj-uuid       :refer :all]))
+            [clj-uuid       :refer :all :exclude [> < =]]))
 
 
 (deftest check-v3-special-cases
@@ -336,4 +336,3 @@
   (testing "v3 oid-ns case-based correctness..."
     (doseq [case +v3-oid-ns-cases+]
       (is (= (second case) (v3 +namespace-oid+ (first case)))))))
-

--- a/test/clj_uuid/v4_test.clj
+++ b/test/clj_uuid/v4_test.clj
@@ -1,7 +1,8 @@
 (ns clj-uuid.v4-test
-  (:refer-clojure :exclude [uuid?])
+  "Custom UUIDs tests"
+  (:refer-clojure :exclude [uuid? max])
   (:require [clojure.test   :refer :all]
-            [clj-uuid       :refer :all]))
+            [clj-uuid       :refer :all :exclude [> < =]]))
 
 
 (deftest check-v4-special-cases
@@ -11,3 +12,11 @@
     (is (= (v4  0 -1)  #uuid "00000000-0000-4000-bfff-ffffffffffff"))
     (is (= (v4 -1  0)  #uuid "ffffffff-ffff-4fff-8000-000000000000"))
     (is (= (v4 -1 -1)  #uuid "ffffffff-ffff-4fff-bfff-ffffffffffff"))))
+
+(deftest check-v8-special-cases
+  (testing "v8 custom UUID"
+    (is (= (v8  0  0)  #uuid "00000000-0000-8000-8000-000000000000"))
+    (is (= (v8  0  1)  #uuid "00000000-0000-8000-8000-000000000001"))
+    (is (= (v8  0 -1)  #uuid "00000000-0000-8000-bfff-ffffffffffff"))
+    (is (= (v8 -1  0)  #uuid "ffffffff-ffff-8fff-8000-000000000000"))
+    (is (= (v8 -1 -1)  #uuid "ffffffff-ffff-8fff-bfff-ffffffffffff"))))

--- a/test/clj_uuid/v5_test.clj
+++ b/test/clj_uuid/v5_test.clj
@@ -1,7 +1,7 @@
 (ns clj-uuid.v5-test
-  (:refer-clojure :exclude [uuid?])
+  (:refer-clojure :exclude [uuid? max])
   (:require [clojure.test   :refer :all]
-            [clj-uuid       :refer :all]))
+            [clj-uuid       :refer :all :exclude [> < =]]))
 
 
 


### PR DESCRIPTION
Hello, I started working on this because I'm bored and have too much time on my hands. I just noticed you created a new branch for this feature. This is my WIP; I'm sure there are several mistakes but I wanted to share early to prevent duplicate effort. feel free to use any or none of it.

- Add support for max, v6, v7, v8 uuids
- Add helper functions for comparing the ordinality of multiple uuids

Draft RFC4122 ammendment
https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-04.html