### PR TITLE
replace deprecated primitive-math ns with clj-commons.primitive-math

### DIFF
--- a/src/clj_uuid/bitmop.clj
+++ b/src/clj_uuid/bitmop.clj
@@ -3,7 +3,7 @@
                             bit-not bit-shift-left bit-shift-right
                             byte short int float long double inc dec
                             zero? min max true? false? unsigned-bit-shift-right])
-  (:require [primitive-math :refer :all]
+  (:require [clj-commons.primitive-math :refer :all]
             [clojure.pprint :refer [cl-format pprint]]
             [clj-uuid.constants :refer :all]
             [clj-uuid.util :refer :all]))


### PR DESCRIPTION
Single-segment namespaces are not recommended in Clojure because they translate to the default java package.

This can cause issues with Java interop and with GraalVM compilation (details https://github.com/clj-easy/graal-build-time/issues/35)

This particular dependency has deprecated the single-segment namespace. https://github.com/clj-commons/primitive-math/blob/a4ce3cb3effbffd2039880a3ed905af60b5cf153/src/primitive_math.clj#L4

This commit proposes to use the newer, non-single-segment namespace

EDIT: related issues: https://github.com/danlentz/clj-uuid/issues/57, https://github.com/danlentz/clj-uuid/issues/58